### PR TITLE
Fp comparisons

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,6 +1,9 @@
 Changes
 =======
 
+0.7.6
+* major redesign of floating point comparison
+
 0.7.5.3
 * added an untag function to simplify tag_cast'ing to an untagged type
 

--- a/math.hpp
+++ b/math.hpp
@@ -20,15 +20,35 @@ namespace unlib {
 
 namespace detail {
 
-template<typename U, typename S, typename V, typename T, std::intmax_t N, std::intmax_t D>
-auto pow(const quantity<U,S,T,V>& q, const std::ratio<N,D>) {
-	return pow_quantity_t<quantity<U,S,T,V>, std::ratio<N,D>>{ std::pow( static_cast<double>(q.get()), static_cast<double>(N)/D ) };
+template<typename Float1, typename T>
+using if_float1_pt_t = typename std::enable_if< is_floating_point<Float1>::value, T >::type;
+template<typename Float1, typename Float2, typename T>
+using if_float2_pt_t = typename std::enable_if< is_floating_point<Float1>::value
+                                            and is_floating_point<Float2>::value, T >::type;
+
+template<typename D, typename S, typename V, typename T, std::intmax_t Nom, std::intmax_t Den>
+auto pow(const quantity<D,S,T,V>& q, const std::ratio<Nom,Den>) {
+	return pow_quantity_t<quantity<D,S,T,V>, std::ratio<Nom,Den>>{ std::pow( static_cast<double>(q.get()), static_cast<double>(Nom)/Den ) };
 }
 
 template<typename U, typename S, typename V, typename T>
 auto pow(const quantity<U,S,T,V>& q, const std::ratio<1,2>) {
 	return pow_quantity_t<quantity<U,S,T,V>,std::ratio<1,2>>(std::sqrt(q.get()));
 }
+
+template<typename TolTag, typename F, typename>
+struct tolerance_aux {
+	using tolerance_tag_type = TolTag;
+	using value_type = F;
+	value_type v;
+};
+
+struct tolerance_val_tag;
+struct tolerance_nom_tag;
+struct tolerance_frc_tag;
+
+template<typename V, typename S=scale_t<1>>
+using fraction = quantity<dimensionless, S, V, no_tag>;
 
 }
 
@@ -111,6 +131,284 @@ auto sqrt(quantity<U,S,T,V> q)                                            {retur
  */
 template<typename U, typename S, typename V, typename T>
 auto cbrt(quantity<U,S,T,V> q)                                            {return pow<std::ratio<1,3>>(q);}
+/** @} */
+
+/**
+ * @brief Provide the minimum of two quantities
+ *
+ * @param lhs, rhs  quantities to compare
+ *
+ * @return minimum value of @p lhs and @p rhs
+ */
+template<typename D, typename F, typename S1, typename S2, typename T>
+auto min(const unlib::quantity<D,S1,F,T> lhs, const unlib::quantity<D,S2,F,T> rhs) {
+	using std::min;
+	return unlib::quantity<D,S1,F,T>{min(lhs.get(), rhs.template get_scaled<S1>())};
+}
+
+/**
+ * @brief Provide the maximum of two quantities
+ *
+ * @param lhs, rhs  quantities to compare
+ *
+ * @return maximum value of @p lhs and @p rhs
+ */
+template<typename D, typename F, typename S1, typename S2, typename T>
+auto max(const unlib::quantity<D,S1,F,T> lhs, const unlib::quantity<D,S2,F,T> rhs) {
+	using std::max;
+	return unlib::quantity<D,S1,F,T>{max(lhs.get(), rhs.template get_scaled<S1>())};
+}
+
+/**
+ * @{
+ *
+ * @brief Floating point comparisons
+ *
+ * Due to the limitations of floating point precision, more often than
+ * never values which, mathematically, ought to be equal, are in fact not
+ * totally equal. Therefore, floating point comparisons should be done with
+ * a certain tolerance.
+ *
+ * This provides a framework for comparing floating point types and
+ * quantities of floating point types. The tolerance can either be an
+ * absolute value, or a fraction of a nominal value. For example, in order to
+ * test whether two masses are equal, the tolerance could be given either as
+ * an absolute value (10mg) or as a fraction (0.1%) of a nominal weight (1t).
+ * The library provides default values for the nominal and the weight, which
+ * can be used, but this must be indicated explicitly.
+ *
+ * The defaults are accessed via traits which can be specialized by users in
+ * order to provide their own defaults.
+ */
+
+constexpr double tolerance_default_nominal  = 1.;     /**< default tolerance nominal for is_near() etc. */
+constexpr double tolerance_default_fraction = 0.0001; /**< default tolerance fraction for is_near() etc. */
+
+/**
+ * @{
+ *
+ * @brief wrapper for tolerance values
+ *
+ * In order to distinguish between tolerance values, nominals, and fractions
+ * in floating point comparisons, those are wrapped in these types.
+ *
+ * @note These are the result types of @ref tolerance_value(), @ref tolerance_nominal(),
+ *       and @ref tolerance_fraction(). Users should not have to deal with them
+ *       directly.
+ */
+template<typename V>             using tolerance_val = detail::tolerance_aux<detail::tolerance_val_tag,V,V>;
+template<typename V>             using tolerance_nom = detail::tolerance_aux<detail::tolerance_nom_tag,V,V>;
+template<typename V, typename Q> using tolerance_frc = detail::tolerance_aux<detail::tolerance_frc_tag,V,Q>;
+/** @} */
+
+/**
+ * @{
+ *
+ * @brief tolerance value calculations
+ *
+ * A tolerance value can be calculated by multiplying a nominal and a fraction.
+ *
+ * @param n  tolerance nominal value
+ * @param f  tolerance fraction value
+ *
+ * @return tolerance value
+ */
+template<typename U, typename S, typename SF, typename V, typename T, typename Q>
+inline constexpr
+tolerance_val<quantity<U,S,V,T>> operator*(tolerance_nom<quantity<U,S,V,T>> n, tolerance_frc<detail::fraction<V,SF>,Q> f)
+{return tolerance_val<quantity<U,S,V,T>>{n.v * f.v.template get_scaled<no_scaling>()};}
+
+template<typename F, typename SF, typename Q>
+inline constexpr
+tolerance_val<F> operator*(tolerance_nom<F> n, tolerance_frc<detail::fraction<F,SF>,Q> f)
+{return tolerance_val<F>{n.v * f.v.template get_scaled<no_scaling>()};}
+/** @} */
+
+/**
+ * @{
+ * @brief tolerance traits
+ *
+ * These provide the necessary functions to obtain default tolerance values,
+ * nominals, and fractions.
+ *
+ * @tparam F  Floating point type.
+ */
+template<typename F>
+struct tolerance_traits {
+	using float_t = detail::if_float1_pt_t<F,F>;
+	using fract_t = detail::fraction<float_t>;
+
+	static constexpr auto value   ()                  {return nominal() * fraction();}
+	static constexpr auto nominal ()                  {return tolerance_nom<float_t        >{        static_cast<float_t>(tolerance_default_nominal ) };}
+	static constexpr auto fraction()                  {return tolerance_frc<fract_t,float_t>{fract_t{static_cast<float_t>(tolerance_default_fraction)}};}
+};
+
+/** specialization for quantities of floating point types */
+template<typename U, typename S, typename F, typename T>
+struct tolerance_traits<quantity<U,S,F,T>> {
+	using float_t = detail::if_float1_pt_t<F,F>;
+	using quant_t = quantity<U,S,float_t,T>;
+	using fract_t = detail::fraction<float_t>;
+
+	static constexpr auto value   ()                  {return nominal() * fraction();}
+	static constexpr auto nominal ()                  {return tolerance_nom<quant_t        >{quant_t{tolerance_traits<float_t>::nominal ().v}};}
+	static constexpr auto fraction()                  {return tolerance_frc<fract_t,quant_t>{        tolerance_traits<float_t>::fraction().v };}
+};
+/** @} */
+
+/**
+ * @{
+ *
+ * @brief create a tolerance value, nominal, or fraction
+ *
+ * These function turn a value into a tolerance value, nominal, or fraction.
+ *
+ * @param val  value to turn into a tolerance value, nominal, or fraction
+ *
+ * @return tolerance value, nominal, or fraction
+ */
+template<typename T>             constexpr auto tolerance_value   (T val) {return tolerance_val<T  >{val};}
+template<typename T>             constexpr auto tolerance_nominal (T nom) {return tolerance_nom<T  >{nom};}
+template<typename T, typename F> constexpr auto tolerance_fraction(F frc) {return tolerance_frc<F,T>{frc};}
+/** @} */
+
+/**
+ * @{
+ *
+ * @brief get the default tolerance value, nominal, or fraction
+ *
+ * These function return the tolerance value, nominal, or fraction for a
+ * given type.
+ *
+ * @return default tolerance value, nominal, or fraction
+ */
+template<typename T>             constexpr auto tolerance_value   ()      {return tolerance_traits<T>::value   ();}
+template<typename T>             constexpr auto tolerance_nominal ()      {return tolerance_traits<T>::nominal ();}
+template<typename T>             constexpr auto tolerance_fraction()      {return tolerance_traits<T>::fraction();}
+/** @} */
+
+namespace detail {
+
+template<typename V, typename F, typename Q> constexpr auto get_tol_val(tolerance_nom<V>   n, tolerance_frc<F,Q> f) {return n * f;}
+template<typename V, typename F, typename Q> constexpr auto get_tol_val(tolerance_frc<F,Q> f, tolerance_nom<V>   n) {return get_tol_val(n,f);}
+template<typename V>                         constexpr auto get_tol_val(tolerance_aux<tolerance_val_tag,V,V>     v) {return v;}
+template<typename V>                         constexpr auto get_tol_val(tolerance_aux<tolerance_nom_tag,V,V>     n) {return get_tol_val(n, tolerance_traits<V>::fraction());}
+template<typename F, typename Q>             constexpr auto get_tol_val(tolerance_aux<tolerance_frc_tag,F,Q>     f) {return get_tol_val(f, tolerance_traits<Q>::nominal ());}
+
+template<typename T1, typename T2, typename Tol> constexpr bool is_near_impl   (T1 lval, T2 rval, tolerance_val<Tol> tol) {using std::abs; return abs(lval-rval) <= abs(tol.v);}
+template<typename T1, typename T2, typename Tol> constexpr bool is_smaller_impl(T1 lval, T2 rval, tolerance_val<Tol> tol) {using std::abs; return not is_near_impl(lval,rval,tol) and lval<rval;}
+template<typename T1, typename T2, typename Tol> constexpr bool is_greater_impl(T1 lval, T2 rval, tolerance_val<Tol> tol) {using std::abs; return not is_near_impl(lval,rval,tol) and lval>rval;}
+
+template<typename T1, typename T2, typename Aux>                 constexpr detail::if_float2_pt_t<T1,T2,bool> is_near   (T1 lval, T2 rval, Aux  tol)             {return is_near_impl   (lval, rval, get_tol_val(tol));}
+template<typename T1, typename T2, typename Aux>                 constexpr detail::if_float2_pt_t<T1,T2,bool> is_smaller(T1 lval, T2 rval, Aux  tol)             {return is_smaller_impl(lval, rval, get_tol_val(tol));}
+template<typename T1, typename T2, typename Aux>                 constexpr detail::if_float2_pt_t<T1,T2,bool> is_greater(T1 lval, T2 rval, Aux  tol)             {return is_greater_impl(lval, rval, get_tol_val(tol));}
+template<typename T1, typename T2, typename Aux1, typename Aux2> constexpr detail::if_float2_pt_t<T1,T2,bool> is_near   (T1 lval, T2 rval, Aux1 tol1, Aux2 tol2) {return is_near_impl   (lval, rval, get_tol_val(tol1,tol2));}
+template<typename T1, typename T2, typename Aux1, typename Aux2> constexpr detail::if_float2_pt_t<T1,T2,bool> is_smaller(T1 lval, T2 rval, Aux1 tol1, Aux2 tol2) {return is_smaller_impl(lval, rval, get_tol_val(tol1,tol2));}
+template<typename T1, typename T2, typename Aux1, typename Aux2> constexpr detail::if_float2_pt_t<T1,T2,bool> is_greater(T1 lval, T2 rval, Aux1 tol1, Aux2 tol2) {return is_greater_impl(lval, rval, get_tol_val(tol1,tol2));}
+
+}
+
+/** @{
+ * @note These algorithms take tolerances. As tolerances, either an absolute
+ *       tolerance value (created via @ref tolerance_value()) or a tolerance
+ *       nominal (created via @ref tolerance_nominal()) and a tolerance
+ *       fraction (created via @ref tolerance_fraction()) can be passed.
+ *       Either the nominal or the fraction can also be omitted, in which
+ *       case the default is obtained via the @ref tolerance_traits.
+ *
+ * @note Tolerances are inclusive. That is, two values which differ exactly by
+ *       the tolerance value are considered equal.
+ *
+ * @note These algorithms will always use the `abs()` value of the tolerance,
+ *       so the sign of the tolerance values will be ignored.
+ *
+ */
+
+/** @{
+ * @brief compare two floating point values
+ *
+ * This compares two floating point values or two quantities of floating point
+ * values.
+ *
+ * @param lval              left value to compare
+ * @param rval              right value to compare
+ * @param tol, tol1, tol2   tolerance
+ *
+ * @note The quantities do not need to be of the same scale, but they need to
+ *       have the same unit, value type, and tag.
+ */
+/**
+ * @{
+ * @return true if both quantities are equal within the given tolerance.
+ */
+template<typename F1, typename F2, typename TT, typename TF, typename X>
+bool is_near   (F1 lval, F2 rval, detail::tolerance_aux<TT,TF,X> tol) {return detail::is_near   (lval, rval, tol);}
+template<typename F1, typename F2, typename TT1, typename TF1, typename TT2, typename TF2, typename X1, typename X2>
+bool is_near   (F1 lval, F2 rval, detail::tolerance_aux<TT1,TF1,X1> tol1, detail::tolerance_aux<TT2,TF2,X2> tol2) {return detail::is_near   (lval, rval, tol1, tol2);}
+/** @} */
+/**
+ * @{
+ * @return true if both quantities are not equal within the given tolerance
+ *         and the left value is smaller than the right value.
+ */
+template<typename F1, typename F2, typename TT1, typename TF1, typename TT2, typename TF2, typename X1, typename X2>
+bool is_smaller(F1 lval, F2 rval, detail::tolerance_aux<TT1,TF1,X1> tol1, detail::tolerance_aux<TT2,TF2,X2> tol2) {return detail::is_smaller(lval, rval, tol1, tol2);}
+template<typename F1, typename F2, typename TT, typename TF, typename X>
+bool is_smaller(F1 lval, F2 rval, detail::tolerance_aux<TT,TF,X> tol) {return detail::is_smaller(lval, rval, tol);}
+/** @} */
+/**
+ * @{
+ * @return true if both quantities are not equal within the given tolerance
+ *         and the left value is greater than the right value.
+ */
+template<typename F1, typename F2, typename TT, typename TF, typename X>
+bool is_greater(F1 lval, F2 rval, detail::tolerance_aux<TT,TF,X> tol) {return detail::is_greater(lval, rval, tol);}
+template<typename F1, typename F2, typename TT1, typename TF1, typename TT2, typename TF2, typename X1, typename X2>
+bool is_greater(F1 lval, F2 rval, detail::tolerance_aux<TT1,TF1,X1> tol1, detail::tolerance_aux<TT2,TF2,X2> tol2) {return detail::is_greater(lval, rval, tol1, tol2);}
+/** @} */
+/** @} */
+
+/** @{
+ * @brief compare a floating point value to zero
+ *
+ * This compares a floating point value, or a quantity of a floating point
+ * value, with zero.
+ *
+ * @param val               value to compare
+ * @param tol, tol1, tol2   tolerance
+ *
+ */
+/* @{
+ *  @return true if the quantity is equal to zero within the tolerance
+ *          given
+ */
+template<typename F, typename TT, typename TF, typename X>
+bool is_near_zero   (F val, detail::tolerance_aux<TT,TF,X> tol) {return detail::is_near   (val,F{}, tol);}
+template<typename F, typename TT1, typename TF1, typename TT2, typename TF2, typename X1, typename X2>
+bool is_near_zero   (F val, detail::tolerance_aux<TT1,TF1,X1> tol1, detail::tolerance_aux<TT2,TF2,X2> tol2) {return detail::is_near   (val,F{}, tol1, tol2);}
+/** @} */
+/* @{
+ *  @return true if the quantity is smaller than zero within the tolerance
+ *          given
+ */
+template<typename F, typename TT, typename TF, typename X>
+bool is_smaller_zero(F val, detail::tolerance_aux<TT,TF,X> tol) {return detail::is_smaller(val,F{}, tol);}
+template<typename F, typename TT1, typename TF1, typename TT2, typename TF2, typename X1, typename X2>
+bool is_smaller_zero(F val, detail::tolerance_aux<TT1,TF1,X1> tol1, detail::tolerance_aux<TT2,TF2,X2> tol2) {return detail::is_smaller(val,F{}, tol1, tol2);}
+/** @} */
+/* @{
+ *  @return true if the quantity is greater than zero within the tolerance
+ *          given
+ */
+template<typename F, typename TT, typename TF, typename X>
+bool is_greater_zero(F val, detail::tolerance_aux<TT,TF,X> tol) {return detail::is_greater(val,F{}, tol);}
+template<typename F, typename TT1, typename TF1, typename TT2, typename TF2, typename X1, typename X2>
+bool is_greater_zero(F val, detail::tolerance_aux<TT1,TF1,X1> tol1, detail::tolerance_aux<TT2,TF2,X2> tol2) {return detail::is_greater(val,F{}, tol1, tol2);}
+/** @} */
+/** @} */
+
+/** @} */
+
 /** @} */
 
 }

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -3,7 +3,17 @@
 
 #include <doctest/doctest.h>
 
+#include <unlib/math.hpp>
 #include <unlib/test/unlib_test.hpp>
+
+namespace {
+
+template<typename D, typename F, typename S1, typename S2, typename T>
+bool is_near_equal(const unlib::quantity<D,S1,F,T> lhs, const unlib::quantity<D,S2,F,T> rhs) {
+	return unlib::is_near(lhs, rhs, unlib::tolerance_nominal(unlib::max(lhs,rhs)));
+}
+
+}
 
 TEST_CASE("common quantities") {
 SUBCASE("time") {
@@ -40,15 +50,15 @@ SUBCASE("time") {
 	CHECK( typeid(1_min) == typeid(             unlib::minute<integer_value_type> ) ); CHECK( 1_min ==              unlib::minute<integer_value_type> {1} );
 	CHECK( typeid(1_h  ) == typeid(             unlib::  hour<integer_value_type> ) ); CHECK( 1_h   ==              unlib::  hour<integer_value_type> {1} );
 
-	CHECK(1000_fs   ==  1_ps ); CHECK(is_near(1000._fs  , 1._ps ));
-	CHECK(1000_ps   ==  1_ns ); CHECK(is_near(1000._ps  , 1._ns ));
-	CHECK(1000_ns   ==  1_us ); CHECK(is_near(1000._ns  , 1._us ));
-	CHECK(1000_us   ==  1_ms ); CHECK(is_near(1000._us  , 1._ms ));
-	CHECK(1000_ms   ==  1_s  ); CHECK(is_near(1000._ms  , 1._s  ));
-	CHECK(   1_min  == 60_s  ); CHECK(is_near(   1._min ,60._s  ));
-	CHECK(   1_h    == 60_min); CHECK(is_near(   1._h   ,60._min));
-	CHECK(   1_d    == 24_h  ); CHECK(is_near(   1._d   ,24._h  ));
-	CHECK(   1_week ==  7_d  ); CHECK(is_near(   1._week, 7._d  ));
+	CHECK(1000_fs   ==  1_ps ); CHECK(is_near_equal(1000._fs  , 1._ps ));
+	CHECK(1000_ps   ==  1_ns ); CHECK(is_near_equal(1000._ps  , 1._ns ));
+	CHECK(1000_ns   ==  1_us ); CHECK(is_near_equal(1000._ns  , 1._us ));
+	CHECK(1000_us   ==  1_ms ); CHECK(is_near_equal(1000._us  , 1._ms ));
+	CHECK(1000_ms   ==  1_s  ); CHECK(is_near_equal(1000._ms  , 1._s  ));
+	CHECK(   1_min  == 60_s  ); CHECK(is_near_equal(   1._min ,60._s  ));
+	CHECK(   1_h    == 60_min); CHECK(is_near_equal(   1._h   ,60._min));
+	CHECK(   1_d    == 24_h  ); CHECK(is_near_equal(   1._d   ,24._h  ));
+	CHECK(   1_week ==  7_d  ); CHECK(is_near_equal(   1._week, 7._d  ));
 }
 
 SUBCASE("mass") {
@@ -84,15 +94,15 @@ SUBCASE("mass") {
 	CHECK( typeid(1_t ) == typeid(             unlib:: ton<integer_value_type> ) ); CHECK( 1_t  ==              unlib:: ton<integer_value_type> {1} );
 	CHECK( typeid(1_Mt) == typeid(unlib::mega <unlib:: ton<integer_value_type>>) ); CHECK( 1_Mt == unlib::mega <unlib:: ton<integer_value_type>>{1} );
 
-	CHECK(1000_fg == 1_pg ); CHECK(is_near(1000._fg,1._pg) );
-	CHECK(1000_pg == 1_ng ); CHECK(is_near(1000._pg,1._ng) );
-	CHECK(1000_ng == 1_ug ); CHECK(is_near(1000._ng,1._ug) );
-	CHECK(1000_ug == 1_mg ); CHECK(is_near(1000._ug,1._mg) );
-	CHECK(1000_mg == 1_g  ); CHECK(is_near(1000._mg,1._g ) );
-	CHECK(1000_g  == 1_kg ); CHECK(is_near(1000._g ,1._kg) );
-	CHECK(1000_kg == 1_t  ); CHECK(is_near(1000._kg,1._t ) );
-	CHECK(1000_t  == 1_kt ); CHECK(is_near(1000._t ,1._kt) );
-	CHECK(1000_kt == 1_Mt ); CHECK(is_near(1000._kt,1._Mt) );
+	CHECK(1000_fg == 1_pg ); CHECK(is_near_equal(1000._fg,1._pg) );
+	CHECK(1000_pg == 1_ng ); CHECK(is_near_equal(1000._pg,1._ng) );
+	CHECK(1000_ng == 1_ug ); CHECK(is_near_equal(1000._ng,1._ug) );
+	CHECK(1000_ug == 1_mg ); CHECK(is_near_equal(1000._ug,1._mg) );
+	CHECK(1000_mg == 1_g  ); CHECK(is_near_equal(1000._mg,1._g ) );
+	CHECK(1000_g  == 1_kg ); CHECK(is_near_equal(1000._g ,1._kg) );
+	CHECK(1000_kg == 1_t  ); CHECK(is_near_equal(1000._kg,1._t ) );
+	CHECK(1000_t  == 1_kt ); CHECK(is_near_equal(1000._t ,1._kt) );
+	CHECK(1000_kt == 1_Mt ); CHECK(is_near_equal(1000._kt,1._Mt) );
 }
 
 SUBCASE("length") {
@@ -123,14 +133,14 @@ SUBCASE("length") {
 	CHECK( typeid(1_m ) == typeid(             unlib::meter<integer_value_type> ) ); CHECK( 1_m  ==              unlib::meter<integer_value_type> {1} );
 	CHECK( typeid(1_km) == typeid(unlib::kilo <unlib::meter<integer_value_type>>) ); CHECK( 1_km == unlib::kilo <unlib::meter<integer_value_type>>{1} );
 
-	CHECK(1000_fm == 1_pm ); CHECK(is_near(1000._fm,1._pm) );
-	CHECK(1000_pm == 1_nm ); CHECK(is_near(1000._pm,1._nm) );
-	CHECK(1000_nm == 1_um ); CHECK(is_near(1000._nm,1._um) );
-	CHECK(1000_um == 1_mm ); CHECK(is_near(1000._um,1._mm) );
-	CHECK(1000_mm == 1_m  ); CHECK(is_near(1000._mm,1._m ) );
-	CHECK( 100_cm == 1_m  ); CHECK(is_near( 100._cm,1._m ) );
-	CHECK(  10_dm == 1_m  ); CHECK(is_near(  10._dm,1._m ) );
-	CHECK(1000_m  == 1_km ); CHECK(is_near(1000._m ,1._km) );
+	CHECK(1000_fm == 1_pm ); CHECK(is_near_equal(1000._fm,1._pm) );
+	CHECK(1000_pm == 1_nm ); CHECK(is_near_equal(1000._pm,1._nm) );
+	CHECK(1000_nm == 1_um ); CHECK(is_near_equal(1000._nm,1._um) );
+	CHECK(1000_um == 1_mm ); CHECK(is_near_equal(1000._um,1._mm) );
+	CHECK(1000_mm == 1_m  ); CHECK(is_near_equal(1000._mm,1._m ) );
+	CHECK( 100_cm == 1_m  ); CHECK(is_near_equal( 100._cm,1._m ) );
+	CHECK(  10_dm == 1_m  ); CHECK(is_near_equal(  10._dm,1._m ) );
+	CHECK(1000_m  == 1_km ); CHECK(is_near_equal(1000._m ,1._km) );
 }
 
 SUBCASE("area") {
@@ -147,11 +157,11 @@ SUBCASE("area") {
 	CHECK( typeid( 1_m2) == typeid(unlib::square_meter<integer_value_type>) );
 	CHECK( typeid(1._m2) == typeid(unlib::square_meter<floatpt_value_type>) );
 
-	CHECK(10000_cm2 ==       1_m2 );                         CHECK(is_near(10000._cm2,      1._m2 ));
-	CHECK(    1_ha  ==   10000_m2 );                         CHECK(is_near(    1._ha ,  10000._m2 ));
-	CHECK(    1_cm2 ==     100_mm2);                         CHECK(is_near(    1._cm2,    100._mm2));
-	CHECK(    1_m2  == 1000000_mm2);                         CHECK(is_near(    1._m2 ,1000000._mm2));
-	CHECK(    1_ha  == unlib::are<integer_value_type>{100}); CHECK(is_near(    1._ha ,unlib::are<floatpt_value_type>{100}));
+	CHECK(10000_cm2 ==       1_m2 );                         CHECK(is_near_equal(10000._cm2,      1._m2 ));
+	CHECK(    1_ha  ==   10000_m2 );                         CHECK(is_near_equal(    1._ha ,  10000._m2 ));
+	CHECK(    1_cm2 ==     100_mm2);                         CHECK(is_near_equal(    1._cm2,    100._mm2));
+	CHECK(    1_m2  == 1000000_mm2);                         CHECK(is_near_equal(    1._m2 ,1000000._mm2));
+	CHECK(    1_ha  == unlib::are<integer_value_type>{100}); CHECK(is_near_equal(    1._ha ,unlib::are<floatpt_value_type>{100}));
 }
 
 SUBCASE("volume") {
@@ -168,11 +178,11 @@ SUBCASE("volume") {
 	CHECK( typeid( 1_l) == typeid(unlib::liter<integer_value_type>) );
 	CHECK( typeid(1._l) == typeid(unlib::liter<floatpt_value_type>) );
 
-	CHECK(1_km3 == 1000000000_m3 ); CHECK(is_near(1._km3, 1000000000._m3 ));
-	CHECK(1_m3  ==       1000_l  ); CHECK(is_near(1._m3 ,       1000._l  ));
-	CHECK(1_l   ==       1000_ml ); CHECK(is_near(1._l  ,       1000._ml ));
-	CHECK(1_l   ==       1000_cm3); CHECK(is_near(1._l  ,       1000._cm3));
-	CHECK(1_ml  ==       1000_mm3); CHECK(is_near(1._ml ,       1000._mm3));
+	CHECK(1_km3 == 1000000000_m3 ); CHECK(is_near_equal(1._km3, 1000000000._m3 ));
+	CHECK(1_m3  ==       1000_l  ); CHECK(is_near_equal(1._m3 ,       1000._l  ));
+	CHECK(1_l   ==       1000_ml ); CHECK(is_near_equal(1._l  ,       1000._ml ));
+	CHECK(1_l   ==       1000_cm3); CHECK(is_near_equal(1._l  ,       1000._cm3));
+	CHECK(1_ml  ==       1000_mm3); CHECK(is_near_equal(1._ml ,       1000._mm3));
 }
 
 SUBCASE("temperature") {
@@ -223,15 +233,15 @@ SUBCASE("current") {
 	CHECK( typeid(1_GA) == typeid(unlib::giga <unlib::ampere<integer_value_type>>) ); CHECK( 1_GA == (unlib::giga <unlib::ampere<integer_value_type>>{1} ) );
 	CHECK( typeid(1_TA) == typeid(unlib::tera <unlib::ampere<integer_value_type>>) ); CHECK( 1_TA == (unlib::tera <unlib::ampere<integer_value_type>>{1} ) );
 
-	CHECK(1000_fA == 1_pA ); CHECK(is_near(1000._fA,1._pA) );
-	CHECK(1000_pA == 1_nA ); CHECK(is_near(1000._pA,1._nA) );
-	CHECK(1000_nA == 1_uA ); CHECK(is_near(1000._nA,1._uA) );
-	CHECK(1000_uA == 1_mA ); CHECK(is_near(1000._uA,1._mA) );
-	CHECK(1000_mA == 1_A  ); CHECK(is_near(1000._mA,1._A ) );
-	CHECK(1000_A  == 1_kA ); CHECK(is_near(1000._A ,1._kA) );
-	CHECK(1000_kA == 1_MA ); CHECK(is_near(1000._kA,1._MA) );
-	CHECK(1000_MA == 1_GA ); CHECK(is_near(1000._MA,1._GA) );
-	CHECK(1000_GA == 1_TA ); CHECK(is_near(1000._GA,1._TA) );
+	CHECK(1000_fA == 1_pA ); CHECK(is_near_equal(1000._fA,1._pA) );
+	CHECK(1000_pA == 1_nA ); CHECK(is_near_equal(1000._pA,1._nA) );
+	CHECK(1000_nA == 1_uA ); CHECK(is_near_equal(1000._nA,1._uA) );
+	CHECK(1000_uA == 1_mA ); CHECK(is_near_equal(1000._uA,1._mA) );
+	CHECK(1000_mA == 1_A  ); CHECK(is_near_equal(1000._mA,1._A ) );
+	CHECK(1000_A  == 1_kA ); CHECK(is_near_equal(1000._A ,1._kA) );
+	CHECK(1000_kA == 1_MA ); CHECK(is_near_equal(1000._kA,1._MA) );
+	CHECK(1000_MA == 1_GA ); CHECK(is_near_equal(1000._MA,1._GA) );
+	CHECK(1000_GA == 1_TA ); CHECK(is_near_equal(1000._GA,1._TA) );
 }
 
 SUBCASE("frequency") {
@@ -275,15 +285,15 @@ SUBCASE("frequency") {
 	CHECK(test::is_same_unit<unlib::hertz<integer_value_type>>(1_GHz) ); CHECK(1_GHz == unlib::giga <unlib::hertz<integer_value_type>>{1} );
 	CHECK(test::is_same_unit<unlib::hertz<integer_value_type>>(1_THz) ); CHECK(1_THz == unlib::tera <unlib::hertz<integer_value_type>>{1} );
 
-	CHECK(1000_fHz == 1_pHz ); CHECK(is_near(1000._fHz,1._pHz) );
-	CHECK(1000_pHz == 1_nHz ); CHECK(is_near(1000._pHz,1._nHz) );
-	CHECK(1000_nHz == 1_uHz ); CHECK(is_near(1000._nHz,1._uHz) );
-	CHECK(1000_uHz == 1_mHz ); CHECK(is_near(1000._uHz,1._mHz) );
-	CHECK(1000_mHz == 1_Hz  ); CHECK(is_near(1000._mHz,1._Hz ) );
-	CHECK(1000_Hz  == 1_kHz ); CHECK(is_near(1000._Hz ,1._kHz) );
-	CHECK(1000_kHz == 1_MHz ); CHECK(is_near(1000._kHz,1._MHz) );
-	CHECK(1000_MHz == 1_GHz ); CHECK(is_near(1000._MHz,1._GHz) );
-	CHECK(1000_GHz == 1_THz ); CHECK(is_near(1000._GHz,1._THz) );
+	CHECK(1000_fHz == 1_pHz ); CHECK(is_near_equal(1000._fHz,1._pHz) );
+	CHECK(1000_pHz == 1_nHz ); CHECK(is_near_equal(1000._pHz,1._nHz) );
+	CHECK(1000_nHz == 1_uHz ); CHECK(is_near_equal(1000._nHz,1._uHz) );
+	CHECK(1000_uHz == 1_mHz ); CHECK(is_near_equal(1000._uHz,1._mHz) );
+	CHECK(1000_mHz == 1_Hz  ); CHECK(is_near_equal(1000._mHz,1._Hz ) );
+	CHECK(1000_Hz  == 1_kHz ); CHECK(is_near_equal(1000._Hz ,1._kHz) );
+	CHECK(1000_kHz == 1_MHz ); CHECK(is_near_equal(1000._kHz,1._MHz) );
+	CHECK(1000_MHz == 1_GHz ); CHECK(is_near_equal(1000._MHz,1._GHz) );
+	CHECK(1000_GHz == 1_THz ); CHECK(is_near_equal(1000._GHz,1._THz) );
 }
 
 SUBCASE("voltage") {
@@ -330,15 +340,15 @@ SUBCASE("voltage") {
 	CHECK(test::is_same_unit<unlib::volt<integer_value_type>>(1_GV) ); CHECK(1_GV == unlib::giga <unlib::volt<integer_value_type>>{1} );
 	CHECK(test::is_same_unit<unlib::volt<integer_value_type>>(1_TV) ); CHECK(1_TV == unlib::tera <unlib::volt<integer_value_type>>{1} );
 
-	CHECK(1000_fV == 1_pV ); CHECK(is_near(1000._fV,1._pV) );
-	CHECK(1000_pV == 1_nV ); CHECK(is_near(1000._pV,1._nV) );
-	CHECK(1000_nV == 1_uV ); CHECK(is_near(1000._nV,1._uV) );
-	CHECK(1000_uV == 1_mV ); CHECK(is_near(1000._uV,1._mV) );
-	CHECK(1000_mV == 1_V  ); CHECK(is_near(1000._mV,1._V ) );
-	CHECK(1000_V  == 1_kV ); CHECK(is_near(1000._V ,1._kV) );
-	CHECK(1000_kV == 1_MV ); CHECK(is_near(1000._kV,1._MV) );
-	CHECK(1000_MV == 1_GV ); CHECK(is_near(1000._MV,1._GV) );
-	CHECK(1000_GV == 1_TV ); CHECK(is_near(1000._GV,1._TV) );
+	CHECK(1000_fV == 1_pV ); CHECK(is_near_equal(1000._fV,1._pV) );
+	CHECK(1000_pV == 1_nV ); CHECK(is_near_equal(1000._pV,1._nV) );
+	CHECK(1000_nV == 1_uV ); CHECK(is_near_equal(1000._nV,1._uV) );
+	CHECK(1000_uV == 1_mV ); CHECK(is_near_equal(1000._uV,1._mV) );
+	CHECK(1000_mV == 1_V  ); CHECK(is_near_equal(1000._mV,1._V ) );
+	CHECK(1000_V  == 1_kV ); CHECK(is_near_equal(1000._V ,1._kV) );
+	CHECK(1000_kV == 1_MV ); CHECK(is_near_equal(1000._kV,1._MV) );
+	CHECK(1000_MV == 1_GV ); CHECK(is_near_equal(1000._MV,1._GV) );
+	CHECK(1000_GV == 1_TV ); CHECK(is_near_equal(1000._GV,1._TV) );
 }
 
 SUBCASE("resistance") {
@@ -385,15 +395,15 @@ SUBCASE("resistance") {
 	CHECK(test::is_same_unit<unlib::ohm<integer_value_type>>(1_GO) ); CHECK(1_GO == unlib::giga <unlib::ohm<integer_value_type>>{1} );
 	CHECK(test::is_same_unit<unlib::ohm<integer_value_type>>(1_TO) ); CHECK(1_TO == unlib::tera <unlib::ohm<integer_value_type>>{1} );
 
-	CHECK(1000_fO == 1_pO ); CHECK(is_near(1000._fO,1._pO) );
-	CHECK(1000_pO == 1_nO ); CHECK(is_near(1000._pO,1._nO) );
-	CHECK(1000_nO == 1_uO ); CHECK(is_near(1000._nO,1._uO) );
-	CHECK(1000_uO == 1_mO ); CHECK(is_near(1000._uO,1._mO) );
-	CHECK(1000_mO == 1_O  ); CHECK(is_near(1000._mO,1._O ) );
-	CHECK(1000_O  == 1_kO ); CHECK(is_near(1000._O ,1._kO) );
-	CHECK(1000_kO == 1_MO ); CHECK(is_near(1000._kO,1._MO) );
-	CHECK(1000_MO == 1_GO ); CHECK(is_near(1000._MO,1._GO) );
-	CHECK(1000_GO == 1_TO ); CHECK(is_near(1000._GO,1._TO) );
+	CHECK(1000_fO == 1_pO ); CHECK(is_near_equal(1000._fO,1._pO) );
+	CHECK(1000_pO == 1_nO ); CHECK(is_near_equal(1000._pO,1._nO) );
+	CHECK(1000_nO == 1_uO ); CHECK(is_near_equal(1000._nO,1._uO) );
+	CHECK(1000_uO == 1_mO ); CHECK(is_near_equal(1000._uO,1._mO) );
+	CHECK(1000_mO == 1_O  ); CHECK(is_near_equal(1000._mO,1._O ) );
+	CHECK(1000_O  == 1_kO ); CHECK(is_near_equal(1000._O ,1._kO) );
+	CHECK(1000_kO == 1_MO ); CHECK(is_near_equal(1000._kO,1._MO) );
+	CHECK(1000_MO == 1_GO ); CHECK(is_near_equal(1000._MO,1._GO) );
+	CHECK(1000_GO == 1_TO ); CHECK(is_near_equal(1000._GO,1._TO) );
 }
 
 SUBCASE("power") {
@@ -470,25 +480,25 @@ SUBCASE("power") {
 	CHECK(test::is_same_unit<unlib::voltampere<integer_value_type>>(1_GVA ) ); CHECK(1_GVA  == unlib::giga <unlib::voltampere<integer_value_type>>{1} );
 	CHECK(test::is_same_unit<unlib::voltampere<integer_value_type>>(1_TVA ) ); CHECK(1_TVA  == unlib::tera <unlib::voltampere<integer_value_type>>{1} );
 
-	CHECK(1000_fW == 1_pW ); CHECK(is_near(1000._fW,1._pW) );
-	CHECK(1000_pW == 1_nW ); CHECK(is_near(1000._pW,1._nW) );
-	CHECK(1000_nW == 1_uW ); CHECK(is_near(1000._nW,1._uW) );
-	CHECK(1000_uW == 1_mW ); CHECK(is_near(1000._uW,1._mW) );
-	CHECK(1000_mW == 1_W  ); CHECK(is_near(1000._mW,1._W ) );
-	CHECK(1000_W  == 1_kW ); CHECK(is_near(1000._W ,1._kW) );
-	CHECK(1000_kW == 1_MW ); CHECK(is_near(1000._kW,1._MW) );
-	CHECK(1000_MW == 1_GW ); CHECK(is_near(1000._MW,1._GW) );
-	CHECK(1000_GW == 1_TW ); CHECK(is_near(1000._GW,1._TW) );
+	CHECK(1000_fW == 1_pW ); CHECK(is_near_equal(1000._fW,1._pW) );
+	CHECK(1000_pW == 1_nW ); CHECK(is_near_equal(1000._pW,1._nW) );
+	CHECK(1000_nW == 1_uW ); CHECK(is_near_equal(1000._nW,1._uW) );
+	CHECK(1000_uW == 1_mW ); CHECK(is_near_equal(1000._uW,1._mW) );
+	CHECK(1000_mW == 1_W  ); CHECK(is_near_equal(1000._mW,1._W ) );
+	CHECK(1000_W  == 1_kW ); CHECK(is_near_equal(1000._W ,1._kW) );
+	CHECK(1000_kW == 1_MW ); CHECK(is_near_equal(1000._kW,1._MW) );
+	CHECK(1000_MW == 1_GW ); CHECK(is_near_equal(1000._MW,1._GW) );
+	CHECK(1000_GW == 1_TW ); CHECK(is_near_equal(1000._GW,1._TW) );
 
-	CHECK(1000_VAr  == 1_kVAr ); CHECK(is_near(1000._VAr ,1._kVAr) );
-	CHECK(1000_kVAr == 1_MVAr ); CHECK(is_near(1000._kVAr,1._MVAr) );
-	CHECK(1000_MVAr == 1_GVAr ); CHECK(is_near(1000._MVAr,1._GVAr) );
-	CHECK(1000_GVAr == 1_TVAr ); CHECK(is_near(1000._GVAr,1._TVAr) );
+	CHECK(1000_VAr  == 1_kVAr ); CHECK(is_near_equal(1000._VAr ,1._kVAr) );
+	CHECK(1000_kVAr == 1_MVAr ); CHECK(is_near_equal(1000._kVAr,1._MVAr) );
+	CHECK(1000_MVAr == 1_GVAr ); CHECK(is_near_equal(1000._MVAr,1._GVAr) );
+	CHECK(1000_GVAr == 1_TVAr ); CHECK(is_near_equal(1000._GVAr,1._TVAr) );
 
-	CHECK(1000_VA  == 1_kVA ); CHECK(is_near(1000._VA ,1._kVA) );
-	CHECK(1000_kVA == 1_MVA ); CHECK(is_near(1000._kVA,1._MVA) );
-	CHECK(1000_MVA == 1_GVA ); CHECK(is_near(1000._MVA,1._GVA) );
-	CHECK(1000_GVA == 1_TVA ); CHECK(is_near(1000._GVA,1._TVA) );
+	CHECK(1000_VA  == 1_kVA ); CHECK(is_near_equal(1000._VA ,1._kVA) );
+	CHECK(1000_kVA == 1_MVA ); CHECK(is_near_equal(1000._kVA,1._MVA) );
+	CHECK(1000_MVA == 1_GVA ); CHECK(is_near_equal(1000._MVA,1._GVA) );
+	CHECK(1000_GVA == 1_TVA ); CHECK(is_near_equal(1000._GVA,1._TVA) );
 }
 
 SUBCASE("energy") {
@@ -544,18 +554,18 @@ SUBCASE("energy") {
 	CHECK(test::is_same_unit<unlib::watt_hour  <integer_value_type>>(1_GWh) ); CHECK(1_GWh == unlib::giga<unlib::watt_hour   <integer_value_type>>{1} );
 	CHECK(test::is_same_unit<unlib::watt_hour  <integer_value_type>>(1_TWh) ); CHECK(1_TWh == unlib::tera<unlib::watt_hour   <integer_value_type>>{1} );
 
-	CHECK(1_Ws == unlib::watt_second<integer_value_type>{unlib::tag_cast(1_J)}); CHECK(is_near(1._Ws,unlib::watt_second<double>{unlib::tag_cast(1._J)}));
+	CHECK(1_Ws == unlib::watt_second<integer_value_type>{unlib::tag_cast(1_J)}); CHECK(is_near_equal(1._Ws,unlib::watt_second<double>{unlib::tag_cast(1._J)}));
 
-	CHECK(1000_fWs == 1_pWs ); CHECK(is_near(1000._fWs,1._pWs) );
-	CHECK(1000_pWs == 1_nWs ); CHECK(is_near(1000._pWs,1._nWs) );
-	CHECK(1000_nWs == 1_uWs ); CHECK(is_near(1000._nWs,1._uWs) );
-	CHECK(1000_uWs == 1_mWs ); CHECK(is_near(1000._uWs,1._mWs) );
-	CHECK(1000_mWs == 1_Ws  ); CHECK(is_near(1000._mWs,1._Ws ) );
-	CHECK(3600_Ws  == 1_Wh  ); CHECK(is_near(3600._Ws ,1._Wh ) );
-	CHECK(1000_Wh  == 1_kWh ); CHECK(is_near(1000._Wh ,1._kWh) );
-	CHECK(1000_kWh == 1_MWh ); CHECK(is_near(1000._kWh,1._MWh) );
-	CHECK(1000_MWh == 1_GWh ); CHECK(is_near(1000._MWh,1._GWh) );
-	CHECK(1000_GWh == 1_TWh ); CHECK(is_near(1000._GWh,1._TWh) );
+	CHECK(1000_fWs == 1_pWs ); CHECK(is_near_equal(1000._fWs,1._pWs) );
+	CHECK(1000_pWs == 1_nWs ); CHECK(is_near_equal(1000._pWs,1._nWs) );
+	CHECK(1000_nWs == 1_uWs ); CHECK(is_near_equal(1000._nWs,1._uWs) );
+	CHECK(1000_uWs == 1_mWs ); CHECK(is_near_equal(1000._uWs,1._mWs) );
+	CHECK(1000_mWs == 1_Ws  ); CHECK(is_near_equal(1000._mWs,1._Ws ) );
+	CHECK(3600_Ws  == 1_Wh  ); CHECK(is_near_equal(3600._Ws ,1._Wh ) );
+	CHECK(1000_Wh  == 1_kWh ); CHECK(is_near_equal(1000._Wh ,1._kWh) );
+	CHECK(1000_kWh == 1_MWh ); CHECK(is_near_equal(1000._kWh,1._MWh) );
+	CHECK(1000_MWh == 1_GWh ); CHECK(is_near_equal(1000._MWh,1._GWh) );
+	CHECK(1000_GWh == 1_TWh ); CHECK(is_near_equal(1000._GWh,1._TWh) );
 }
 
 SUBCASE("electric charge") {
@@ -605,16 +615,16 @@ SUBCASE("electric charge") {
 	CHECK(test::is_same_unit<unlib::ampere_hour  <integer_value_type>::unit_type>(1_GAh) ); CHECK(1_GAh == unlib::giga <unlib::ampere_hour  <integer_value_type>>{1} );
 	CHECK(test::is_same_unit<unlib::ampere_hour  <integer_value_type>::unit_type>(1_TAh) ); CHECK(1_TAh == unlib::tera <unlib::ampere_hour  <integer_value_type>>{1} );
 
-	CHECK(1000_fAs == 1_pAs ); CHECK(is_near(1000._fAs,1._pAs) );
-	CHECK(1000_pAs == 1_nAs ); CHECK(is_near(1000._pAs,1._nAs) );
-	CHECK(1000_nAs == 1_uAs ); CHECK(is_near(1000._nAs,1._uAs) );
-	CHECK(1000_uAs == 1_mAs ); CHECK(is_near(1000._uAs,1._mAs) );
-	CHECK(1000_mAs == 1_As  ); CHECK(is_near(1000._mAs,1._As ) );
-	CHECK(3600_As  == 1_Ah  ); CHECK(is_near(3600._As ,1._Ah ) );
-	CHECK(1000_Ah  == 1_kAh ); CHECK(is_near(1000._Ah ,1._kAh) );
-	CHECK(1000_kAh == 1_MAh ); CHECK(is_near(1000._kAh,1._MAh) );
-	CHECK(1000_MAh == 1_GAh ); CHECK(is_near(1000._MAh,1._GAh) );
-	CHECK(1000_GAh == 1_TAh ); CHECK(is_near(1000._GAh,1._TAh) );
+	CHECK(1000_fAs == 1_pAs ); CHECK(is_near_equal(1000._fAs,1._pAs) );
+	CHECK(1000_pAs == 1_nAs ); CHECK(is_near_equal(1000._pAs,1._nAs) );
+	CHECK(1000_nAs == 1_uAs ); CHECK(is_near_equal(1000._nAs,1._uAs) );
+	CHECK(1000_uAs == 1_mAs ); CHECK(is_near_equal(1000._uAs,1._mAs) );
+	CHECK(1000_mAs == 1_As  ); CHECK(is_near_equal(1000._mAs,1._As ) );
+	CHECK(3600_As  == 1_Ah  ); CHECK(is_near_equal(3600._As ,1._Ah ) );
+	CHECK(1000_Ah  == 1_kAh ); CHECK(is_near_equal(1000._Ah ,1._kAh) );
+	CHECK(1000_kAh == 1_MAh ); CHECK(is_near_equal(1000._kAh,1._MAh) );
+	CHECK(1000_MAh == 1_GAh ); CHECK(is_near_equal(1000._MAh,1._GAh) );
+	CHECK(1000_GAh == 1_TAh ); CHECK(is_near_equal(1000._GAh,1._TAh) );
 }
 
 SUBCASE("pressure") {
@@ -668,16 +678,16 @@ SUBCASE("pressure") {
 	CHECK(test::is_same_unit<unlib::pascal_<integer_value_type>::unit_type>(1_GPa ) ); CHECK(1_GPa  == unlib::giga <unlib::pascal_<integer_value_type>>{1} );
 	CHECK(test::is_same_unit<unlib::pascal_<integer_value_type>::unit_type>(1_TPa ) ); CHECK(1_TPa  == unlib::tera <unlib::pascal_<integer_value_type>>{1} );
 
-	CHECK(1000_pbar == 1_nbar ); CHECK(is_near(1000._pbar,1._nbar) );
-	CHECK(1000_nbar == 1_ubar ); CHECK(is_near(1000._nbar,1._ubar) );
-	CHECK(1000_ubar == 1_mbar ); CHECK(is_near(1000._ubar,1._mbar) );
-	CHECK(1000_mbar == 1_bar  ); CHECK(is_near(1000._mbar,1._bar ) );
-	CHECK( 100_kPa  == 1_bar  ); CHECK(is_near( 100._kPa ,1._bar ) );
-	CHECK( 100_Pa   == 1_hPa  ); CHECK(is_near( 100._Pa  ,1._hPa ) );
-	CHECK(1000_Pa   == 1_kPa  ); CHECK(is_near(1000._Pa  ,1._kPa ) );
-	CHECK(1000_kPa  == 1_MPa  ); CHECK(is_near(1000._kPa ,1._MPa ) );
-	CHECK(1000_MPa  == 1_GPa  ); CHECK(is_near(1000._MPa ,1._GPa ) );
-	CHECK(1000_GPa  == 1_TPa  ); CHECK(is_near(1000._GPa ,1._TPa ) );
+	CHECK(1000_pbar == 1_nbar ); CHECK(is_near_equal(1000._pbar,1._nbar) );
+	CHECK(1000_nbar == 1_ubar ); CHECK(is_near_equal(1000._nbar,1._ubar) );
+	CHECK(1000_ubar == 1_mbar ); CHECK(is_near_equal(1000._ubar,1._mbar) );
+	CHECK(1000_mbar == 1_bar  ); CHECK(is_near_equal(1000._mbar,1._bar ) );
+	CHECK( 100_kPa  == 1_bar  ); CHECK(is_near_equal( 100._kPa ,1._bar ) );
+	CHECK( 100_Pa   == 1_hPa  ); CHECK(is_near_equal( 100._Pa  ,1._hPa ) );
+	CHECK(1000_Pa   == 1_kPa  ); CHECK(is_near_equal(1000._Pa  ,1._kPa ) );
+	CHECK(1000_kPa  == 1_MPa  ); CHECK(is_near_equal(1000._kPa ,1._MPa ) );
+	CHECK(1000_MPa  == 1_GPa  ); CHECK(is_near_equal(1000._MPa ,1._GPa ) );
+	CHECK(1000_GPa  == 1_TPa  ); CHECK(is_near_equal(1000._GPa ,1._TPa ) );
 }
 
 SUBCASE("velocity") {
@@ -704,7 +714,7 @@ SUBCASE("velocity") {
 	CHECK(test::is_same_unit<unlib::    meter_per_second<integer_value_type>>(1_m_per_s ) ); CHECK(1_m_per_s  == unlib::    meter_per_second<integer_value_type>{1} );
 	CHECK(test::is_same_unit<unlib::kilometer_per_hour  <integer_value_type>>(1_km_per_h) ); CHECK(1_km_per_h == unlib::kilometer_per_hour  <integer_value_type>{1} );
 
-	CHECK(10_m_per_s == 36_km_per_h); CHECK(is_near(1.0_m_per_s,3.6_km_per_h));
+	CHECK(10_m_per_s == 36_km_per_h); CHECK(is_near_equal(1.0_m_per_s,3.6_km_per_h));
 }
 
 SUBCASE("volumetric flow rate") {
@@ -716,7 +726,7 @@ SUBCASE("volumetric flow rate") {
 	CHECK(test::is_same_unit<unlib::liter_per_hour<double>>(1._l / 1._h) );
 	CHECK(test::is_same_unit<unlib::liter_per_hour<VT    >>(1_l_per_h  ));
 
-	CHECK(1_l_per_h == unlib::liter_per_hour<integer_value_type>{1}); CHECK(is_near(1._l_per_h,unlib::liter_per_hour<floatpt_value_type>{1}));
+	CHECK(1_l_per_h == unlib::liter_per_hour<integer_value_type>{1}); CHECK(is_near_equal(1._l_per_h,unlib::liter_per_hour<floatpt_value_type>{1}));
 }
 
 SUBCASE("scalar") {
@@ -742,4 +752,3 @@ SUBCASE("scalar") {
 }
 
 }
-

--- a/test/test_math.cpp
+++ b/test/test_math.cpp
@@ -2,9 +2,447 @@
 
 #include <doctest/doctest.h>
 
+#include <unlib/common.hpp>
 #include <unlib/test/unlib_test.hpp>
 
+namespace {
+
+struct comparison_table_result {
+	bool                        value;
+	bool                        nominal;
+	bool                        fraction;
+	bool                        nominal_fraction;
+
+	int                         line;
+};
+
+template<typename Float>
+struct zero_comparison_table_entry : comparison_table_result {
+	Float                      val;
+	Float                      tol1;
+	Float                      tol2;
+
+	zero_comparison_table_entry(comparison_table_result ctr, Float v, Float t1, Float t2)
+	: comparison_table_result{ctr}, val{v}, tol1{t1}, tol2{t2} {}
+};
+
+template<typename Float>
+struct comparison_table_entry : comparison_table_result {
+	Float                      lhs;
+	Float                      rhs;
+	Float                      tol1;
+	Float                      tol2;
+
+	comparison_table_entry(comparison_table_result ctr, Float l, Float r, Float t1, Float t2)
+	: comparison_table_result{ctr}, lhs{l}, rhs{r}, tol1{t1}, tol2{t2} {}
+};
+
+template<typename Float>
+struct comparison_tests {
+	using Watt = unlib::watt<Float>;
+	using kW = unlib::kilo<Watt>;
+	using zero_entry_t = zero_comparison_table_entry<Float>;
+	using      entry_t =      comparison_table_entry<Float>;
+
+	static void is_near_v(const entry_t& entry) {
+		INFO(__FILE__ << ":" << entry.line << ": " << entry.value << " == comparison_tests<" << typeid(Float).name() << ">::is_near_v(" << entry.lhs << ", " << entry.rhs << ", tolerance_value(" << entry.tol1 << "))");
+		CHECK( entry.value == unlib::is_near(        entry.lhs  ,        entry.rhs  , unlib::tolerance_value(        entry.tol1  )) );
+		CHECK( entry.value == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( entry.value == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( entry.value == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( entry.value == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( entry.value == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( entry.value == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( entry.value == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( entry.value == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+	}
+	static void is_near_v(const zero_entry_t& entry) {
+		INFO(__FILE__ << ":" << entry.line << ": " << entry.value << " == comparison_tests<" << typeid(Float).name() << ">::is_near_zero_v(" << entry.val << ", tolerance_value(" << entry.tol1 << "))");
+		CHECK( entry.value == unlib::is_near_zero(        entry.val  , unlib::tolerance_value(        entry.tol1  )) );
+		CHECK( entry.value == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( entry.value == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( entry.value == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( entry.value == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+	}
+	static void is_near_n(const entry_t& entry) {
+		INFO(__FILE__ << ":" << entry.line << ": " << entry.nominal << " == comparison_tests<" << typeid(Float).name() << ">::is_near_n(" << entry.lhs << ", " << entry.rhs << ", tolerance_nominal(" << entry.tol1 << "))");
+		CHECK( entry.nominal == unlib::is_near(        entry.lhs  ,        entry.rhs  , unlib::tolerance_nominal(        entry.tol1  )) );
+		CHECK( entry.nominal == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( entry.nominal == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( entry.nominal == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( entry.nominal == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( entry.nominal == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( entry.nominal == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( entry.nominal == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( entry.nominal == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+	}
+	static void is_near_n(const zero_entry_t& entry) {
+		INFO(__FILE__ << ":" << entry.line << ": " << entry.nominal << " == comparison_tests<" << typeid(Float).name() << ">::is_near_zero_n(" << entry.val << ", tolerance_nominal(" << entry.tol1 << "))");
+		CHECK( entry.nominal == unlib::is_near_zero(        entry.val  , unlib::tolerance_nominal(        entry.tol1  )) );
+		CHECK( entry.nominal == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( entry.nominal == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( entry.nominal == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( entry.nominal == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+	}
+	static void is_near_f(const entry_t& entry) {
+		INFO(__FILE__ << ":" << entry.line << ": " << entry.fraction << " == comparison_tests<" << typeid(Float).name() << ">::is_near_f(" << entry.lhs << ", " << entry.rhs << ", tolerance_fraction(" << entry.tol1 << "))");
+		CHECK( entry.fraction == unlib::is_near(        entry.lhs  ,        entry.rhs  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( entry.fraction == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( entry.fraction == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( entry.fraction == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( entry.fraction == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( entry.fraction == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( entry.fraction == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( entry.fraction == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( entry.fraction == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+	}
+	static void is_near_f(const zero_entry_t& entry) {
+		INFO(__FILE__ << ":" << entry.line << ": " << entry.fraction << " == comparison_tests<" << typeid(Float).name() << ">::is_near_zero_f(" << entry.val << ", tolerance_fraction(" << entry.tol1 << "))");
+		CHECK( entry.fraction == unlib::is_near_zero(        entry.val  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( entry.fraction == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( entry.fraction == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( entry.fraction == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( entry.fraction == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+	}
+	static void is_near_fn(const entry_t& entry) {
+		INFO(__FILE__ << ":" << entry.line << ": " << entry.nominal_fraction << " == comparison_tests<" << typeid(Float).name() << ">::is_near_fn(" << entry.lhs << ", " << entry.rhs << ", tolerance_fraction(" << entry.tol1 << ")" << ", tolerance_nominal(" << entry.tol2 << "))");
+		CHECK( entry.nominal_fraction == unlib::is_near(        entry.lhs  ,        entry.rhs  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(        entry.tol2  )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+	}
+	static void is_near_fn(const zero_entry_t& entry) {
+		INFO(__FILE__ << ":" << entry.line << ": " << entry.nominal_fraction << " == comparison_tests<" << typeid(Float).name() << ">::is_near_zero_fn(" << entry.val << ", tolerance_fraction(" << entry.tol1 << ")" << ", tolerance_nominal(" << entry.tol2 << "))");
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(        entry.val  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(        entry.tol2  )) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( entry.nominal_fraction == unlib::is_near_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+	}
+	template<typename TEntry>
+	static void is_near(const TEntry& entry) {
+		is_near_v(entry);
+		is_near_n(entry);
+		is_near_f(entry);
+		is_near_fn(entry);
+	}
+
+	static void is_smaller_v(const entry_t& entry) {
+		const bool smaller = is_smaller_helper(entry.lhs, entry.rhs, entry.value);
+		INFO(__FILE__ << ":" << entry.line << ": " << smaller << " == comparison_tests<" << typeid(Float).name() << ">::is_smaller_v(" << entry.lhs << ", " << entry.rhs << ", tolerance_value(" << entry.tol1 << "))");
+		CHECK( smaller == unlib::is_smaller(        entry.lhs  ,        entry.rhs  , unlib::tolerance_value(        entry.tol1  )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+	}
+	static void is_smaller_v(const zero_entry_t& entry) {
+		const bool smaller = is_smaller_helper(entry.val, Float{}, entry.value);
+		INFO(__FILE__ << ":" << entry.line << ": " << smaller << " == comparison_tests<" << typeid(Float).name() << ">::is_smaller_zero_v(" << entry.val << ", tolerance_value(" << entry.tol1 << "))");
+		CHECK( smaller == unlib::is_smaller_zero(        entry.val  , unlib::tolerance_value(        entry.tol1  )) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+	}
+	static void is_smaller_n(const entry_t& entry) {
+		const bool smaller = is_smaller_helper(entry.lhs, entry.rhs, entry.nominal);
+		INFO(__FILE__ << ":" << entry.line << ": " << smaller << " == comparison_tests<" << typeid(Float).name() << ">::is_smaller_n(" << entry.lhs << ", " << entry.rhs << ", tolerance_nominal(" << entry.tol1 << "))");
+		CHECK( smaller == unlib::is_smaller(        entry.lhs  ,        entry.rhs  , unlib::tolerance_nominal(        entry.tol1  )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+	}
+	static void is_smaller_n(const zero_entry_t& entry) {
+		const bool smaller = is_smaller_helper(entry.val, Float{}, entry.nominal);
+		INFO(__FILE__ << ":" << entry.line << ": " << smaller << " == comparison_tests<" << typeid(Float).name() << ">::is_smaller_zero_n(" << entry.val << ", tolerance_nominal(" << entry.tol1 << "))");
+		CHECK( smaller == unlib::is_smaller_zero(        entry.val  , unlib::tolerance_nominal(        entry.tol1  )) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+	}
+	static void is_smaller_f(const entry_t& entry) {
+		const bool smaller = is_smaller_helper(entry.lhs, entry.rhs, entry.fraction);
+		INFO(__FILE__ << ":" << entry.line << ": " << smaller << " == comparison_tests<" << typeid(Float).name() << ">::is_smaller_f(" << entry.lhs << ", " << entry.rhs << ", tolerance_fraction(" << entry.tol1 << "))");
+		CHECK( smaller == unlib::is_smaller(        entry.lhs  ,        entry.rhs  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+	}
+	static void is_smaller_f(const zero_entry_t& entry) {
+		const bool smaller = is_smaller_helper(entry.val, Float{}, entry.fraction);
+		INFO(__FILE__ << ":" << entry.line << ": " << smaller << " == comparison_tests<" << typeid(Float).name() << ">::is_smaller_zero_f(" << entry.val << ", tolerance_fraction(" << entry.tol1 << "))");
+		CHECK( smaller == unlib::is_smaller_zero(        entry.val  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+	}
+	static void is_smaller_fn(const entry_t& entry) {
+		const bool smaller = is_smaller_helper(entry.lhs, entry.rhs, entry.nominal_fraction);
+		INFO(__FILE__ << ":" << entry.line << ": " << smaller << " == comparison_tests<" << typeid(Float).name() << ">::is_smaller_fn(" << entry.lhs << ", " << entry.rhs << ", tolerance_fraction(" << entry.tol1 << ")" << ", tolerance_nominal(" << entry.tol2 << "))");
+		CHECK( smaller == unlib::is_smaller(        entry.lhs  ,        entry.rhs  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(        entry.tol2  )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+	}
+	static void is_smaller_fn(const zero_entry_t& entry) {
+		const bool smaller = is_smaller_helper(entry.val, Float{}, entry.nominal_fraction);
+		INFO(__FILE__ << ":" << entry.line << ": " << smaller << " == comparison_tests<" << typeid(Float).name() << ">::is_smaller_zero_fn(" << entry.val << ", tolerance_fraction(" << entry.tol1 << ")" << ", tolerance_nominal(" << entry.tol2 << "))");
+		CHECK( smaller == unlib::is_smaller_zero(        entry.val  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(        entry.tol2  )) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( smaller == unlib::is_smaller_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+	}
+	template<typename TEntry>
+	static void is_smaller(const TEntry& entry) {
+		is_smaller_v(entry);
+		is_smaller_n(entry);
+		is_smaller_f(entry);
+		is_smaller_fn(entry);
+	}
+
+	static void is_greater_v(const entry_t& entry) {
+		const bool greater = is_greater_helper(entry.lhs, entry.rhs, entry.value);
+		INFO(__FILE__ << ":" << entry.line << ": " << greater << " == comparison_tests<" << typeid(Float).name() << ">::is_greater_v(" << entry.lhs << ", " << entry.rhs << ", tolerance_value(" << entry.tol1 << "))");
+		CHECK( greater == unlib::is_greater(        entry.lhs  ,        entry.rhs  , unlib::tolerance_value(        entry.tol1  )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+	}
+	static void is_greater_v(const zero_entry_t& entry) {
+		const bool greater = is_greater_helper(entry.val, Float{}, entry.value);
+		INFO(__FILE__ << ":" << entry.line << ": " << greater << " == comparison_tests<" << typeid(Float).name() << ">::is_greater_zero_v(" << entry.val << ", tolerance_value(" << entry.tol1 << "))");
+		CHECK( greater == unlib::is_greater_zero(        entry.val  , unlib::tolerance_value(        entry.tol1  )) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_value(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_value(kW{Watt{entry.tol1}})) );
+	}
+	static void is_greater_n(const entry_t& entry) {
+		const bool greater = is_greater_helper(entry.lhs, entry.rhs, entry.nominal);
+		INFO(__FILE__ << ":" << entry.line << ": " << greater << " == comparison_tests<" << typeid(Float).name() << ">::is_greater_n(" << entry.lhs << ", " << entry.rhs << ", tolerance_nominal(" << entry.tol1 << "))");
+		CHECK( greater == unlib::is_greater(        entry.lhs  ,        entry.rhs  , unlib::tolerance_nominal(        entry.tol1  )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+	}
+	static void is_greater_n(const zero_entry_t& entry) {
+		const bool greater = is_greater_helper(entry.val, Float{}, entry.nominal);
+		INFO(__FILE__ << ":" << entry.line << ": " << greater << " == comparison_tests<" << typeid(Float).name() << ">::is_greater_zero_n(" << entry.val << ", tolerance_nominal(" << entry.tol1 << "))");
+		CHECK( greater == unlib::is_greater_zero(        entry.val  , unlib::tolerance_nominal(        entry.tol1  )) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_nominal(   Watt{entry.tol1} )) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_nominal(kW{Watt{entry.tol1}})) );
+	}
+	static void is_greater_f(const entry_t& entry) {
+		const bool greater = is_greater_helper(entry.lhs, entry.rhs, entry.fraction);
+		INFO(__FILE__ << ":" << entry.line << ": " << greater << " == comparison_tests<" << typeid(Float).name() << ">::is_greater_f(" << entry.lhs << ", " << entry.rhs << ", tolerance_fraction(" << entry.tol1 << "))");
+		CHECK( greater == unlib::is_greater(        entry.lhs  ,        entry.rhs  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+	}
+	static void is_greater_f(const zero_entry_t& entry) {
+		const bool greater = is_greater_helper(entry.val, Float{}, entry.fraction);
+		INFO(__FILE__ << ":" << entry.line << ": " << greater << " == comparison_tests<" << typeid(Float).name() << ">::is_greater_zero_f(" << entry.val << ", tolerance_fraction(" << entry.tol1 << "))");
+		CHECK( greater == unlib::is_greater_zero(        entry.val  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1/1000))) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1     ))) );
+	}
+	static void is_greater_fn(const entry_t& entry) {
+		const bool greater = is_greater_helper(entry.lhs, entry.rhs, entry.nominal_fraction);
+		INFO(__FILE__ << ":" << entry.line << ": " << greater << " == comparison_tests<" << typeid(Float).name() << ">::is_greater_fn(" << entry.lhs << ", " << entry.rhs << ", tolerance_fraction(" << entry.tol1 << ")" << ", tolerance_nominal(" << entry.tol2 << "))");
+		CHECK( greater == unlib::is_greater(        entry.lhs  ,        entry.rhs  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(        entry.tol2  )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(   Watt{entry.lhs} ,kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},   Watt{entry.rhs} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater(kW{Watt{entry.lhs}},kW{Watt{entry.rhs}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+	}
+	static void is_greater_fn(const zero_entry_t& entry) {
+		const bool greater = is_greater_helper(entry.val, Float{}, entry.nominal_fraction);
+		INFO(__FILE__ << ":" << entry.line << ": " << greater << " == comparison_tests<" << typeid(Float).name() << ">::is_greater_zero_fn(" << entry.val << ", tolerance_fraction(" << entry.tol1 << ")" << ", tolerance_nominal(" << entry.tol2 << "))");
+		CHECK( greater == unlib::is_greater_zero(        entry.val  , unlib::tolerance_fraction<Float>(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(        entry.tol2  )) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater_zero(   Watt{entry.val} , unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<kW   >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(   Watt{entry.tol2} )) );
+		CHECK( greater == unlib::is_greater_zero(kW{Watt{entry.val}}, unlib::tolerance_fraction<Watt >(unlib::fraction<Float>(entry.tol1)), unlib::tolerance_nominal(kW{Watt{entry.tol2}})) );
+	}
+	template<typename TEntry>
+	static void is_greater(const TEntry& entry) {
+		is_greater_v(entry);
+		is_greater_n(entry);
+		is_greater_f(entry);
+		is_greater_fn(entry);
+	}
+
+private:
+	static bool is_smaller_helper(Float lhs, Float rhs, bool is_near) {return !is_near && lhs < rhs;}
+	static bool is_greater_helper(Float lhs, Float rhs, bool is_near) {return !is_near && lhs > rhs;}
+};
+
+}
+
 TEST_CASE("math") {
+//	CHECK( unlib::is_smaller(1.0, 0.99, unlib::tolerance_value(0.1)) );
+//	CHECK( unlib::is_smaller(0.99, 1.0, unlib::tolerance_value(0.1)) );
+
 	using namespace unlib;
 
 	using value_type = double;
@@ -23,11 +461,10 @@ TEST_CASE("math") {
 		quantity_a z {  0};
 		quantity_a lt{-gt.get()};
 
-		CHECK(is_near(unlib::abs(gt),gt));
-		CHECK(is_near(unlib::abs( z), z));
-		CHECK(is_near(unlib::abs(lt),gt));
+		CHECK(unlib::abs(gt) == gt);
+		CHECK(unlib::abs( z) ==  z);
+		CHECK(unlib::abs(lt) == gt);
 	}
-
 
 	SUBCASE("pow") {
 		using quantity0 = quantity<dimensionless, scale_t<1>, value_type>;
@@ -199,4 +636,118 @@ TEST_CASE("math") {
 		CHECK(typeid(cb_root_3) == typeid(quantity_cbrt));
 		CHECK(cb_root_3.get() == doctest::Approx(4));
 	}
+
+}
+
+TEST_CASE_TEMPLATE("is_near, is_smaller, is_greater", Float, float, double, long double) {
+
+	const auto  f_tiny       = Float{  0.0000001f};
+	const auto  f_0_0        = Float{  0.0f      };
+	const auto  f_0_001      = Float{  0.001f    };
+	const auto  f_0_01       = Float{  0.01f     };
+	const auto  f_1_0        = Float{  1.0f      };
+	const auto  f_1_1        = Float{  1.1f      };
+	const auto  f_3_0        = Float{  3.0f      };
+	const auto f_49_99999    = Float{ 49.99999f  };
+	const auto f_50_0        = Float{ 50.0f      };
+	const auto f_50_1        = Float{ 50.1f      };
+	const auto f_100_0       = Float{100.0f      };
+	const auto f_150_0       = Float{150.0f      };
+	const auto f_1000_0      = Float{1000.0f     };
+	const auto f_epsilon     = std::numeric_limits<Float>::epsilon();
+	const auto f_2_epsilon   = f_epsilon * 2;
+	const auto tolerance_def_nominal  = static_cast<Float>(unlib::tolerance_default_nominal );
+	const auto tolerance_def_fraction = static_cast<Float>(unlib::tolerance_default_fraction);
+
+	const auto frac_0_001 = unlib::fraction<Float>{f_0_001};
+
+	using unlib::fraction;
+
+	const comparison_table_entry<Float> comparison_table[] =
+		//                               |-----------comparison_table_result----------|-------------operands------------|------tolerances------|
+		//                                value, nominal, fraction, frac&nom                lhs,     rhs                , tol1       ,   tol2
+		{ comparison_table_entry<Float>{ {true , true   , true    , true   , __LINE__},     f_1_0,   f_1_0              , f_tiny     ,   f_1_0 }
+		, comparison_table_entry<Float>{ {true , true   , true    , true   , __LINE__},     f_0_0,   f_0_0              , f_tiny     ,   f_1_0 }
+		, comparison_table_entry<Float>{ {true , false  , true    , true   , __LINE__},     f_1_0,   f_1_0 + f_epsilon  , f_2_epsilon,   f_1_0 }
+		, comparison_table_entry<Float>{ {true , false  , true    , true   , __LINE__},   f_100_0, f_150_0              , f_50_1     ,   f_1_0 }
+		, comparison_table_entry<Float>{ {false, false  , false   , false  , __LINE__},     f_1_0,   f_1_1              , f_tiny     ,   f_1_0 }
+		, comparison_table_entry<Float>{ {false, false  , false   , false  , __LINE__},     f_1_1,   f_1_0              , f_tiny     ,   f_1_0 }
+		, comparison_table_entry<Float>{ {false, false  , false   , false  , __LINE__},     f_1_0,   f_1_0 + f_2_epsilon, f_epsilon  ,   f_1_0 }
+		, comparison_table_entry<Float>{ {false, false  , false   , false  , __LINE__},   f_100_0, f_150_0              , f_49_99999 ,   f_1_0 }
+		, comparison_table_entry<Float>{ {true , true   , true    , true   , __LINE__},     f_1_0,   f_1_0              , f_tiny     ,   f_3_0 }
+		, comparison_table_entry<Float>{ {true , true   , true    , true   , __LINE__},     f_0_0,   f_0_0              , f_tiny     ,   f_3_0 }
+		, comparison_table_entry<Float>{ {true , false  , true    , true   , __LINE__},     f_1_0,   f_1_0 + f_epsilon  , f_2_epsilon,   f_3_0 }
+		, comparison_table_entry<Float>{ {true , false  , true    , true   , __LINE__},   f_100_0, f_150_0              , f_50_1     ,   f_3_0 }
+		, comparison_table_entry<Float>{ {false, false  , false   , false  , __LINE__},     f_1_0,   f_1_1              , f_tiny     ,   f_3_0 }
+		, comparison_table_entry<Float>{ {false, false  , false   , false  , __LINE__},     f_1_1,   f_1_0              , f_tiny     ,   f_3_0 }
+		, comparison_table_entry<Float>{ {false, false  , false   , true   , __LINE__},     f_1_0,   f_1_0 + f_2_epsilon, f_epsilon  ,   f_3_0 }
+		, comparison_table_entry<Float>{ {false, false  , false   , true   , __LINE__},   f_100_0, f_150_0              , f_49_99999 ,   f_3_0 }
+		, comparison_table_entry<Float>{ {true , true   , true    , true   , __LINE__},     f_1_0,   f_1_0              , f_tiny     ,   f_1_0 }
+		, comparison_table_entry<Float>{ {true , true   , true    , true   , __LINE__},     f_0_0,   f_0_0              , f_tiny     ,   f_0_0 }
+		, comparison_table_entry<Float>{ {true , false  , true    , true   , __LINE__},     f_1_0,   f_1_0 + f_epsilon  , f_2_epsilon,   f_1_0 }
+		, comparison_table_entry<Float>{ {true , false  , true    , false  , __LINE__},   f_100_0, f_150_0              , f_50_1     , f_0_001 }
+		, comparison_table_entry<Float>{ {false, false  , false   , false  , __LINE__},     f_1_0,   f_1_1              , f_tiny     ,   f_1_0 }
+		, comparison_table_entry<Float>{ {false, false  , false   , false  , __LINE__},     f_1_1,   f_1_0              , f_tiny     ,   f_1_1 }
+		, comparison_table_entry<Float>{ {false, false  , false   , false  , __LINE__},     f_1_0,   f_1_0 + f_2_epsilon, f_epsilon  ,   f_1_0 }
+		, comparison_table_entry<Float>{ {false, false  , false   , false  , __LINE__},   f_100_0, f_150_0              , f_49_99999 , f_0_001 }
+		};
+
+	const zero_comparison_table_entry<Float> zero_comparison_table[] =
+		//                                    |----------comparison_table_result----------|--value---|----tolerances----|
+		//                                     value, nominal, fraction, frac&nom                      tol1  , tol2
+		{ zero_comparison_table_entry<Float>{ {true , true   , true    , true   , __LINE__}, f_0_0   , f_tiny, f_1_0     }
+		, zero_comparison_table_entry<Float>{ {true , false  , true    , true   , __LINE__}, f_0_001 , f_0_01, f_1_0     }
+		, zero_comparison_table_entry<Float>{ {true , true   , true    , true   , __LINE__}, f_0_0   , f_tiny, f_3_0     }
+		, zero_comparison_table_entry<Float>{ {true , false  , true    , true   , __LINE__}, f_0_001 , f_0_01, f_3_0     }
+		, zero_comparison_table_entry<Float>{ {true , true   , true    , true   , __LINE__}, f_0_0   , f_tiny, f_50_0    }
+		, zero_comparison_table_entry<Float>{ {true , false  , true    , true   , __LINE__}, f_0_001 , f_0_01, f_50_0    }
+		, zero_comparison_table_entry<Float>{ {true , true   , true    , true   , __LINE__}, f_0_0   , f_tiny, f_tiny    }
+		, zero_comparison_table_entry<Float>{ {true , false  , true    , false  , __LINE__}, f_0_001 , f_0_01, f_tiny    }
+		, zero_comparison_table_entry<Float>{ {true , true   , true    , true   , __LINE__}, f_0_0   , f_tiny, f_epsilon }
+		, zero_comparison_table_entry<Float>{ {true , false  , true    , false  , __LINE__}, f_0_001 , f_0_01, f_epsilon }
+		};
+
+	SUBCASE("tolerances") {
+		using Watt = unlib::watt<Float>;
+		SUBCASE("types") {
+			CHECK( typeid(unlib::tolerance_value   <Float>()) == typeid(unlib::tolerance_val<Float>) );
+			CHECK( typeid(unlib::tolerance_value   <Watt >()) == typeid(unlib::tolerance_val<Watt >) );
+			CHECK( typeid(unlib::tolerance_nominal <Float>()) == typeid(unlib::tolerance_nom<Float>) );
+			CHECK( typeid(unlib::tolerance_nominal <Watt >()) == typeid(unlib::tolerance_nom<Watt >) );
+			CHECK( typeid(unlib::tolerance_fraction<Float>()) == typeid(unlib::tolerance_frc<fraction<Float>,Float>) );
+			CHECK( typeid(unlib::tolerance_fraction<Watt >()) == typeid(unlib::tolerance_frc<fraction<Float>,Watt >) );
+		}
+		SUBCASE("values") {
+			CHECK( unlib::tolerance_value           (     f_0_001    ).v       == doctest::Approx(     f_0_001   ) );
+			CHECK( unlib::tolerance_value           (Watt{f_0_001   }).v.get() == doctest::Approx(Watt{f_0_001   }.get()) );
+			CHECK( unlib::tolerance_nominal         (     f_1000_0   ).v       == doctest::Approx(     f_1000_0  ) );
+			CHECK( unlib::tolerance_nominal         (Watt{f_1000_0  }).v.get() == doctest::Approx(Watt{f_1000_0  }.get()) );
+			CHECK( unlib::tolerance_fraction<Float>(                 frac_0_001 ).v.get() == doctest::Approx(                frac_0_001 .get()) );
+			CHECK( unlib::tolerance_fraction<Watt  >(fraction<Float>{f_1000_0  }).v.get() == doctest::Approx(fraction<Float>{f_1000_0  }.get()) );
+			SUBCASE("default values") {
+				CHECK( unlib::tolerance_value   <Float>().v       == doctest::Approx(     tolerance_def_nominal*tolerance_def_fraction ) );
+				CHECK( unlib::tolerance_value   <Watt >().v.get() == doctest::Approx(Watt{tolerance_def_nominal*tolerance_def_fraction}.get()) );
+				CHECK( unlib::tolerance_nominal <Float>().v       == doctest::Approx(     tolerance_def_nominal ) );
+				CHECK( unlib::tolerance_nominal <Watt >().v.get() == doctest::Approx(Watt{tolerance_def_nominal}.get()) );
+				CHECK( unlib::tolerance_fraction<Float>().v.get() == doctest::Approx(fraction<Float>{tolerance_def_fraction}.get()) );
+				CHECK( unlib::tolerance_fraction<Watt >().v.get() == doctest::Approx(fraction<Float>{tolerance_def_fraction}.get()) );
+			}
+		}
+	}
+
+	SUBCASE("comparison between two numbers") {
+		for(auto& entry : comparison_table) {
+			comparison_tests<Float>::is_near   (entry);
+			comparison_tests<Float>::is_smaller(entry);
+			comparison_tests<Float>::is_greater(entry);
+		}
+	}
+	SUBCASE("comparison with zero") {
+		for(auto& entry : zero_comparison_table) {
+			comparison_tests<Float>::is_near   (entry);
+			comparison_tests<Float>::is_smaller(entry);
+			comparison_tests<Float>::is_greater(entry);
+		}
+	}
+
 }

--- a/test/test_quantity.cpp
+++ b/test/test_quantity.cpp
@@ -91,7 +91,7 @@ SUBCASE("quantity values") {
 		}
 		{
 			test_quantity q;
-			CHECK(q.is_near_zero()); CHECK(is_near_zero(q));
+			CHECK(q.get() == value_type{});
 		}
 	}
 	SUBCASE("value is stored correctly") {
@@ -102,35 +102,10 @@ SUBCASE("quantity values") {
 		const test_quantity q2(q1);
 		CHECK( v == doctest::Approx(q2.get()) );
 		test_quantity q3;
-		CHECK( q3.is_near_zero() );     CHECK( is_near_zero(q3) );
+		CHECK( q3.get() == value_type{});
 		q3 = q1;
-		CHECK( not q3.is_near_zero() ); CHECK( not is_near_zero(q3) );
+		CHECK( q3.get() != value_type{});
 		CHECK( v == doctest::Approx(q3.get()) );
-	}
-
-	SUBCASE("is_near_zero") {
-		using test_q = test_quantity::rescale_to<scale_t<1,2>>;
-
-		const test_q q1{};
-		CHECK( q1.is_near_zero() ); CHECK( is_near_zero(q1) );
-
-		const value_type e1 = 101*std::numeric_limits<float>::epsilon();
-		const test_q q2{e1};
-		CHECK( not q2.is_near_zero()   ); CHECK( not is_near_zero(q2)         );
-		CHECK(     q2.is_near_zero(e1) ); CHECK(     is_near_zero(q2,e1) );
-
-		const value_type e2 = 100*std::numeric_limits<float>::epsilon();
-		const test_q q3{e2};
-		CHECK( q3.is_near_zero()   ); CHECK( is_near_zero(q3)    );
-		CHECK( q3.is_near_zero(e1) ); CHECK( is_near_zero(q3,e1) );
-		CHECK( q3.is_near_zero(e2) ); CHECK( is_near_zero(q3,e2) );
-
-		const value_type e3 = 99*std::numeric_limits<float>::epsilon();
-		const test_q q4{e3};
-		CHECK( q4.is_near_zero()   ); CHECK( is_near_zero(q4)    );
-		CHECK( q4.is_near_zero(e1) ); CHECK( is_near_zero(q4,e1) );
-		CHECK( q4.is_near_zero(e2) ); CHECK( is_near_zero(q4,e2) );
-		CHECK( q4.is_near_zero(e3) ); CHECK( is_near_zero(q4,e3) );
 	}
 
 	SUBCASE("values are rescaled properly") {
@@ -207,71 +182,41 @@ SUBCASE("quantity values") {
 		test_quantity q3{v*2};
 		test_mq mq1{q1};
 
-		CHECK( is_near(q1,q1) );
-		CHECK( is_near(q1,q2) );
-		CHECK( is_near(q2,q1) );
-		CHECK( is_near(q2,q2) );
+		CHECK( q1 == q1 );
+		CHECK( q1 == q2 );
+		CHECK( q2 == q1 );
+		CHECK( q2 == q2 );
 
 		CHECK( q1 <= q2 );
 		CHECK( q1 >= q2 );
 		CHECK( q2 <= q1 );
 		CHECK( q2 >= q1 );
 
-		CHECK( not is_near(q1,q3) );
-		CHECK( not is_near(q3,q1) );
+		CHECK( q1 != q3 );
+		CHECK( q3 != q1 );
 
 		CHECK( q1 <  q3 );
 		CHECK( q3 >  q1 );
 		CHECK( q1 <= q3 );
 		CHECK( q3 >= q1 );
 
-		CHECK( is_near(mq1, q1) );
-		CHECK( is_near( q1,mq1) );
-		CHECK( is_near(mq1, q2) );
-		CHECK( is_near( q2,mq1) );
+		CHECK( mq1 ==  q1 );
+		CHECK(  q1 == mq1 );
+		CHECK( mq1 ==  q2 );
+		CHECK(  q2 == mq1 );
 
 		CHECK( mq1 <=  q2 );
 		CHECK( mq1 >=  q2 );
 		CHECK(  q2 <= mq1 );
 		CHECK(  q2 >= mq1 );
 
-		CHECK( not is_near(mq1, q3) );
-		CHECK( not is_near( q3,mq1) );
+		CHECK( mq1 !=  q3 );
+		CHECK(  q3 != mq1 );
 
 		CHECK( mq1 <   q3 );
 		CHECK(  q3 >  mq1 );
 		CHECK( mq1 <=  q3 );
 		CHECK(  q3 >= mq1 );
-	}
-
-	SUBCASE("is_near") {
-		using local_value_type = double;
-		using test_q = test_quantity::rescale_to<scale_t<1,2>>;
-
-		const local_value_type e1 = 50*std::numeric_limits<float>::epsilon();
-
-		const test_q q0{}, q1{e1}, q2{42}, q3{42}, q4{42 + e1}, q5{2 * 42.};
-
-		CHECK(     q0.is_near(q1) ); CHECK(     is_near(q0,q1) );
-		CHECK( not q0.is_near(q2) ); CHECK( not is_near(q0,q2) );
-		CHECK( not q0.is_near(q3) ); CHECK( not is_near(q0,q3) );
-		CHECK( not q0.is_near(q4) ); CHECK( not is_near(q0,q4) );
-		CHECK( not q0.is_near(q5) ); CHECK( not is_near(q0,q5) );
-
-		CHECK( not q1.is_near(q2) ); CHECK( not is_near(q1,q2) );
-		CHECK( not q1.is_near(q3) ); CHECK( not is_near(q1,q3) );
-		CHECK( not q1.is_near(q3) ); CHECK( not is_near(q1,q3) );
-		CHECK( not q1.is_near(q4) ); CHECK( not is_near(q1,q4) );
-		CHECK( not q1.is_near(q5) ); CHECK( not is_near(q1,q5) );
-
-		CHECK(     q2.is_near(q3) ); CHECK(     is_near(q2,q3) );
-		CHECK(     q2.is_near(q4) ); CHECK(     is_near(q2,q4) );
-		CHECK( not q2.is_near(q5) ); CHECK( not is_near(q2,q5) );
-
-		CHECK(     q3.is_near(q4) ); CHECK(     is_near(q3,q4) );
-		CHECK( not q3.is_near(q5) ); CHECK( not is_near(q3,q5) );
-
-		CHECK( not q4.is_near(q5) ); CHECK( not is_near(q4,q5) );
 	}
 
 	SUBCASE("quantities can be signed") {
@@ -280,9 +225,9 @@ SUBCASE("quantity values") {
 		test_quantity q1{v};
 		test_quantity q2{-v};
 
-		CHECK(q1.is_near(+q1));
-		CHECK(q2.is_near(-q1));
-		CHECK(q1.is_near(-q2));
+		CHECK(q1 == +q1);
+		CHECK(q2 == -q1);
+		CHECK(q1 == -q2);
 	}
 }
 

--- a/test/unlib_test.cpp
+++ b/test/unlib_test.cpp
@@ -15,14 +15,21 @@ inline void remove_substr(std::string& name, const std::string& substr) {
 	for(std::string::size_type idx = name.find(substr); idx != std::string::npos; idx = name.find(substr))
 		name.erase(idx, substr.size());
 }
+inline void replace_substr(std::string& name, const std::string& substr, const std::string& replacement) {
+	for(std::string::size_type idx = name.find(substr); idx != std::string::npos; idx = name.find(substr))
+		name.replace(idx, substr.size(), replacement);
+}
 inline void remove_prefix(std::string& name, std::string prefix) {
 	remove_substr(name, prefix + "::");
 }
 inline std::string filter_type_name(std::string name) {
 	remove_prefix(name, "unlib");
-	remove_prefix(name, "std");
-	remove_substr(name, "ll");
+	remove_prefix(name, "std"  );
+	remove_substr(name, "ll"   );
 	remove_substr(name, "ratio");
+
+	replace_substr(name, "> >", ">>");
+
 	return name;
 }
 


### PR DESCRIPTION
This is a major redesign of the floating point comparison feature (`is_near()`). The library now offers `is_near()`, `is_smaller()`, and `is_greater()` and all of these can be passed either a tolerance _value_ or a tolerance _fraction_ and a _nominal_. The library will calculate a _value_ from the latter two by multiplying them. There are default values for all three of these. 